### PR TITLE
fix: Add permissions to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,8 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Checkout
         uses: actions/checkout@v2


### PR DESCRIPTION
This commit adds the 'contents: write' permission to the release workflow. This is necessary for the 'create-release' action to be able to create a GitHub release.